### PR TITLE
Implement full page requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # SteamAPI
 
-This is a proof of concept for using C# & .NET to interact with the Steam Web API and Steam Community XML Profiles.
+This is a proof of concept for using C# & .NET to interact with the Steam Web API and Steam Community Profiles.
 
 ### What is included?
 
 Currently, there is the ability to find:
 - SteamID64 via Steam Community URL (XML)
 - Steam Username via Steam Community URL (XML) & SteamID64 (Web API)
+- Steam User Level via Steam Community URL (HTML)
 - VAC Ban Status via Steam Community URL (XML)
 - Steam Join Date via Steam Community URL (XML) & SteamID64 (Web API)
 - Owned Games via SteamID64 (Web API)
@@ -24,4 +25,10 @@ Additionally, it comes with all of the costs of using the Steam Web API key, whi
 
 It also does *not* save the API key locally, so it will have to be provided every time.
 
+Some features (specifically requesting full HTML pages) lead to extreme slowdown and many requests may eventually lead to access being temporarily denied.
+
 It's also currently untested with private Steam accounts -- I only tested it with my own. I'd expect a crash however.
+
+### Exclusive to this branch
+- Ability to find user level
+- Ability to determine game tags (obtained via the store page)

--- a/SteamAPI/Game.cs
+++ b/SteamAPI/Game.cs
@@ -14,6 +14,7 @@ namespace SteamAPI
         public uint playtime_2weeks;
         public uint playtime_forever;
         public bool appinfo;
+        public List<string> tags;
 
         // Constructors
         public Game()
@@ -23,6 +24,7 @@ namespace SteamAPI
             title = "";
             playtime_2weeks = 0;
             appinfo = false;
+            tags = new List<string>();
         }
 
         // As it goes at the moment, these constructors are unused.
@@ -33,6 +35,7 @@ namespace SteamAPI
             title = "";
             playtime_2weeks = 0;
             appinfo = false;
+            tags = new List<string>();
         }
 
         public Game(uint _appid, uint _playtime_forever, string _title, uint _playtime_2weeks)
@@ -42,10 +45,17 @@ namespace SteamAPI
             title = _title;
             playtime_2weeks = _playtime_2weeks;
             appinfo = true;
+            tags = new List<string>();
         }
 
         public override string ToString()
         {
+            string tagsString = "";
+            if (tags.Count > 0)
+            {
+                tagsString = "\n\tTags: " + string.Join(", ", tags);
+            }
+
             if (!appinfo)
             {
                 return $"App ID: {appid}\n\tTotal Playtime: {playtime_forever}\n\n";
@@ -54,7 +64,7 @@ namespace SteamAPI
             else
             {
                 // Playtime is always delivered in minutes, hours is how Steam displays it and probably a bit better for our usage?
-                return $"App ID: {appid}\n\tTitle: {title}\n\tTotal Hours: {Math.Round((float)playtime_forever / 60, 2)}\n\t\tLast Two Weeks: {Math.Round((float)playtime_2weeks / 60, 2)}\n\n";
+                return $"App ID: {appid}\n\tTitle: {title}{tagsString}\n\tTotal Hours: {Math.Round((float)playtime_forever / 60, 2)}\n\t\tLast Two Weeks: {Math.Round((float)playtime_2weeks / 60, 2)}\n\n";
             }
         }
     }

--- a/SteamAPI/Game.cs
+++ b/SteamAPI/Game.cs
@@ -53,7 +53,7 @@ namespace SteamAPI
             string tagsString = "";
             if (tags.Count > 0)
             {
-                tagsString = "\n\tTags: " + string.Join(", ", tags);
+                tagsString = "\n\tTags: " + string.Join(", ", tags.GetRange(0,Math.Min(tags.Count, 5)));
             }
 
             if (!appinfo)

--- a/SteamAPI/HTMLRequest.cs
+++ b/SteamAPI/HTMLRequest.cs
@@ -1,7 +1,11 @@
-﻿namespace SteamAPI
+﻿using System.Net;
+
+namespace SteamAPI
 {
     public class HTMLRequest
     {
+        private static HttpClient httpClient = new HttpClient();
+
         // I'm keeping this public for now because it might be useful at some point?
         public async static Task<string> RequestHTMLPage(string url)
         {
@@ -13,7 +17,6 @@
 
             try
             {
-                HttpClient httpClient = new HttpClient();
                 return await httpClient.GetStringAsync(url);
             }
 
@@ -24,10 +27,21 @@
             }
         }
 
+        // This is mainly for bypassing the age verification check on store pages
+        public async static Task<string> RequestPOST(string url, HttpContent content)
+        {
+            return await httpClient.PostAsync(url, content).Result.Content.ReadAsStringAsync();
+        }
+
         // Most interaction should be performed using this, however.
         public static string GetHTMLPage(string url)
         {
             return RequestHTMLPage(url).Result;
+        }
+
+        public static string GetPOST(string url, HttpContent content)
+        {
+            return RequestPOST(url, content).Result;
         }
     }
 }

--- a/SteamAPI/Output.cs
+++ b/SteamAPI/Output.cs
@@ -1,0 +1,44 @@
+﻿/*
+ *      -- Output.cs --
+ *      By: Ash Duck
+ *      Date: 05/02/2024
+ *      Description: This file provides a nice output for some information like loading.
+ */
+
+namespace SteamAPI
+{
+	public class Output
+	{
+		public static void LogProgress(string progress)
+		{
+			//
+			// This method outputs to the console a percentage (amateurly calculated) for how 'ready' the data is.
+			// If verbose, it will instead output how many operations it's on and how long it's taken.
+			// Verbosity is hardcoded (bool: verbose)
+			// Requires: verbose = true/false, progress string
+			//
+
+			if (verbose)
+			{
+				current = ((DateTimeOffset)DateTime.Now).ToUnixTimeMilliseconds();
+				Console.Write(" (Took {2}ms)\n{0} -- {1}", _LoadingProgress, progress, current - last);
+				last = current;
+			}
+
+			else
+			{
+				Console.WriteLine("Loading: {0}%", Math.Round((float)_LoadingProgress * 100 / operationCount));
+			}
+
+			_LoadingProgress++;
+		}
+
+		private static int _LoadingProgress;
+		private static long current;
+		private static long last = ((DateTimeOffset)DateTime.Now).ToUnixTimeMilliseconds();
+		private static int operationCount = 28;             // This is obtained via testing on just my personal account, probably not too accurate
+		private static bool verbose = false;
+
+    }
+}
+

--- a/SteamAPI/Program.cs
+++ b/SteamAPI/Program.cs
@@ -42,6 +42,11 @@ SteamAPI.SteamXML.GetUserDetails(testUser, steam_url);
 
 // To access the full games list, we need to use the Steam Web API.
 
+SteamAPI.SteamUserPage.GetUserLevel(testUser, steam_url);
+
+// This populates the user with:
+//      1: Their Steam user level (more 'real' accounts have higher levels)
+
 SteamAPI.SteamWeb.GetOwnedGames(testUser);
 
 // This populates their games list with metadata including:

--- a/SteamAPI/SteamAPI.csproj
+++ b/SteamAPI/SteamAPI.csproj
@@ -8,4 +8,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Fizzler.Systems.HtmlAgilityPack" Version="1.2.1" />
+  </ItemGroup>
 </Project>

--- a/SteamAPI/SteamStorePage.cs
+++ b/SteamAPI/SteamStorePage.cs
@@ -1,0 +1,42 @@
+﻿/*
+ *      -- SteamStorePage.cs --
+ *      By: Ash Duck
+ *      Date: 05/02/2024
+ *      Description: This file retrieves data from Steam Store Pages (in HTML) and parses relevant information.
+ */
+
+using System;
+
+namespace SteamAPI
+{
+	public class SteamStorePage
+	{
+        // We want to be using this sparingly - full webpage requests are significantly slower than making API/XML requests
+		public static void GetCommunityTags(Game game)
+		{
+            //
+            // This method obtains the community tags from the Steam store to conclude the genre of the game.
+            // Requires: game != null
+            //
+
+            // We know the appID already, and Steam makes it very convenient to find store pages based on this.
+            string StorePage = HTMLRequest.GetHTMLPage("https://store.steampowered.com/app/"+game.appid);
+            HtmlAgilityPack.HtmlDocument document = new HtmlAgilityPack.HtmlDocument();
+            document.LoadHtml(StorePage);
+
+            // Next we can obtain the tags (all have class 'app_tag')
+            IEnumerable<HtmlAgilityPack.HtmlNode> tagNodes = Fizzler.Systems.HtmlAgilityPack.HtmlNodeSelection.QuerySelectorAll(document.DocumentNode, "a.app_tag");
+
+            // Iterate through and add to the game's tags.
+            foreach (HtmlAgilityPack.HtmlNode node in tagNodes)
+            {
+                // Tags have awkward formatting like "\r\n\t\t\t\t\t\t\t\t\t\t\t\tFPS\t\t\t\t\t\t\t\t\t\t\t\t"
+                // This filter removes all the leading/trailing special characters.
+                string filteredText = node.InnerText.Substring(14, node.InnerText.Length - 26);
+                game.tags.Add(filteredText);
+            }
+
+        }
+	}
+}
+

--- a/SteamAPI/SteamStorePage.cs
+++ b/SteamAPI/SteamStorePage.cs
@@ -5,7 +5,10 @@
  *      Description: This file retrieves data from Steam Store Pages (in HTML) and parses relevant information.
  */
 
-using System;
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Text.Json;
 
 namespace SteamAPI
 {
@@ -21,10 +24,50 @@ namespace SteamAPI
 
             // We know the appID already, and Steam makes it very convenient to find store pages based on this.
             Output.LogProgress("Requesting store page");
-            string StorePage = HTMLRequest.GetHTMLPage("https://store.steampowered.com/app/"+game.appid);
+
+            // Games with 'mature content' will redirect to a age verification page upon loading.
+            // We need to simulate someone passing the age-verification check.
+
+            string storePage = HTMLRequest.GetHTMLPage("https://store.steampowered.com/app/" + game.appid);
             Output.LogProgress("Converting store page to document");
             HtmlAgilityPack.HtmlDocument document = new HtmlAgilityPack.HtmlDocument();
-            document.LoadHtml(StorePage);
+            document.LoadHtml(storePage);
+
+            // After loading the page, we can check to see if we got age-gated.
+            IEnumerable<HtmlAgilityPack.HtmlNode> ageGateNode = Fizzler.Systems.HtmlAgilityPack.HtmlNodeSelection.QuerySelectorAll(document.DocumentNode, "div.agegate_birthday_desc");
+            if (ageGateNode.Count() != 0)             // On a regular store page, this won't exist.
+            {
+
+                // Assuming that we've been age-gated, then we need to find the session ID to spoof the POST request.
+                // We have the full document at this point, and it's stored as a JavaScript variable. Unfortunately, HTMLAgilityPack
+                // doesn't support finding JavaScript variables out of that, so we have to use Regex.
+
+                Match match = Regex.Match(storePage, "g_sessionID = ");
+
+                // The content string has to match *exactly* what Valve's CheckAgeGateSubmit(callbackFunc) function POSTS to the server
+                // on their store page. It has a fixed arbitrary valid date alongside the obtained session id. It also needs to have
+                // the same content-type and probably encoding?
+
+                // Session ids are always 24 characters long and are always prefaced with "g_sessionID = " so that needs omitting.
+                StringContent content = new StringContent(
+                    $"sessionid={storePage.Substring(match.Index + 15, 24)}&ageDay=5&ageMonth=February&ageYear=2004",
+                    Encoding.UTF8,
+                    "application/x-www-form-urlencoded"
+                    );
+
+                // GetPOST returns the string response from the server, but it's not needed unless for debugging purposes.
+                // However, if it's needed, success code 1 is what we're looking for. 15 means the data supplied is malformed.
+                // If 15 is encountered in the future, CheckAgeGateSubmit has probably been updated and needs matching again.
+
+                HTMLRequest.GetPOST($"https://store.steampowered.com/agecheckset/app/{game.appid}/", content);
+
+                // The Steam website uses a cookie to record whether the user wants to see mature content or not. However, it's not
+                // required as long as the user remains in the same session, which will happen as long as the program is open.
+                // After this, load the original page again to get the tags.
+
+                storePage = HTMLRequest.GetHTMLPage("https://store.steampowered.com/app/" + game.appid);
+                document.LoadHtml(storePage);
+            }
 
             // Next we can obtain the tags (all have class 'app_tag')
             Output.LogProgress("Obtaining tags");

--- a/SteamAPI/SteamStorePage.cs
+++ b/SteamAPI/SteamStorePage.cs
@@ -22,68 +22,70 @@ namespace SteamAPI
             // Requires: game != null
             //
 
-            // We know the appID already, and Steam makes it very convenient to find store pages based on this.
-            Output.LogProgress("Requesting store page");
-
-            // Games with 'mature content' will redirect to a age verification page upon loading.
-            // We need to simulate someone passing the age-verification check.
-
-            string storePage = HTMLRequest.GetHTMLPage("https://store.steampowered.com/app/" + game.appid);
-            Output.LogProgress("Converting store page to document");
-            HtmlAgilityPack.HtmlDocument document = new HtmlAgilityPack.HtmlDocument();
-            document.LoadHtml(storePage);
-
-            // After loading the page, we can check to see if we got age-gated.
-            IEnumerable<HtmlAgilityPack.HtmlNode> ageGateNode = Fizzler.Systems.HtmlAgilityPack.HtmlNodeSelection.QuerySelectorAll(document.DocumentNode, "div.agegate_birthday_desc");
-            if (ageGateNode.Count() != 0)             // On a regular store page, this won't exist.
+            if (game.tags.Count == 0)
             {
+                // We know the appID already, and Steam makes it very convenient to find store pages based on this.
+                Output.LogProgress("Requesting store page");
 
-                // Assuming that we've been age-gated, then we need to find the session ID to spoof the POST request.
-                // We have the full document at this point, and it's stored as a JavaScript variable. Unfortunately, HTMLAgilityPack
-                // doesn't support finding JavaScript variables out of that, so we have to use Regex.
+                // Games with 'mature content' will redirect to a age verification page upon loading.
+                // We need to simulate someone passing the age-verification check.
 
-                Match match = Regex.Match(storePage, "g_sessionID = ");
-
-                // The content string has to match *exactly* what Valve's CheckAgeGateSubmit(callbackFunc) function POSTS to the server
-                // on their store page. It has a fixed arbitrary valid date alongside the obtained session id. It also needs to have
-                // the same content-type and probably encoding?
-
-                // Session ids are always 24 characters long and are always prefaced with "g_sessionID = " so that needs omitting.
-                StringContent content = new StringContent(
-                    $"sessionid={storePage.Substring(match.Index + 15, 24)}&ageDay=5&ageMonth=February&ageYear=2004",
-                    Encoding.UTF8,
-                    "application/x-www-form-urlencoded"
-                    );
-
-                // GetPOST returns the string response from the server, but it's not needed unless for debugging purposes.
-                // However, if it's needed, success code 1 is what we're looking for. 15 means the data supplied is malformed.
-                // If 15 is encountered in the future, CheckAgeGateSubmit has probably been updated and needs matching again.
-
-                HTMLRequest.GetPOST($"https://store.steampowered.com/agecheckset/app/{game.appid}/", content);
-
-                // The Steam website uses a cookie to record whether the user wants to see mature content or not. However, it's not
-                // required as long as the user remains in the same session, which will happen as long as the program is open.
-                // After this, load the original page again to get the tags.
-
-                storePage = HTMLRequest.GetHTMLPage("https://store.steampowered.com/app/" + game.appid);
+                string storePage = HTMLRequest.GetHTMLPage("https://store.steampowered.com/app/" + game.appid);
+                Output.LogProgress("Converting store page to document");
+                HtmlAgilityPack.HtmlDocument document = new HtmlAgilityPack.HtmlDocument();
                 document.LoadHtml(storePage);
+
+                // After loading the page, we can check to see if we got age-gated.
+                IEnumerable<HtmlAgilityPack.HtmlNode> ageGateNode = Fizzler.Systems.HtmlAgilityPack.HtmlNodeSelection.QuerySelectorAll(document.DocumentNode, "div.agegate_birthday_desc");
+                if (ageGateNode.Count() != 0)             // On a regular store page, this won't exist.
+                {
+
+                    // Assuming that we've been age-gated, then we need to find the session ID to spoof the POST request.
+                    // We have the full document at this point, and it's stored as a JavaScript variable. Unfortunately, HTMLAgilityPack
+                    // doesn't support finding JavaScript variables out of that, so we have to use Regex.
+
+                    Match match = Regex.Match(storePage, "g_sessionID = ");
+
+                    // The content string has to match *exactly* what Valve's CheckAgeGateSubmit(callbackFunc) function POSTS to the server
+                    // on their store page. It has a fixed arbitrary valid date alongside the obtained session id. It also needs to have
+                    // the same content-type and probably encoding?
+
+                    // Session ids are always 24 characters long and are always prefaced with "g_sessionID = " so that needs omitting.
+                    StringContent content = new StringContent(
+                        $"sessionid={storePage.Substring(match.Index + 15, 24)}&ageDay=5&ageMonth=February&ageYear=2004",
+                        Encoding.UTF8,
+                        "application/x-www-form-urlencoded"
+                        );
+
+                    // GetPOST returns the string response from the server, but it's not needed unless for debugging purposes.
+                    // However, if it's needed, success code 1 is what we're looking for. 15 means the data supplied is malformed.
+                    // If 15 is encountered in the future, CheckAgeGateSubmit has probably been updated and needs matching again.
+
+                    HTMLRequest.GetPOST($"https://store.steampowered.com/agecheckset/app/{game.appid}/", content);
+
+                    // The Steam website uses a cookie to record whether the user wants to see mature content or not. However, it's not
+                    // required as long as the user remains in the same session, which will happen as long as the program is open.
+                    // After this, load the original page again to get the tags.
+
+                    storePage = HTMLRequest.GetHTMLPage("https://store.steampowered.com/app/" + game.appid);
+                    document.LoadHtml(storePage);
+                }
+
+                // Next we can obtain the tags (all have class 'app_tag')
+                Output.LogProgress("Obtaining tags");
+                IEnumerable<HtmlAgilityPack.HtmlNode> tagNodes = Fizzler.Systems.HtmlAgilityPack.HtmlNodeSelection.QuerySelectorAll(document.DocumentNode, "a.app_tag");
+
+                // Iterate through and add to the game's tags.
+                Output.LogProgress("Adding tags to list");
+                foreach (HtmlAgilityPack.HtmlNode node in tagNodes)
+                {
+                    // Tags have awkward formatting like "\r\n\t\t\t\t\t\t\t\t\t\t\t\tFPS\t\t\t\t\t\t\t\t\t\t\t\t"
+                    // This filter removes all the leading/trailing special characters.
+                    string filteredText = node.InnerText.Substring(14, node.InnerText.Length - 26);
+                    game.tags.Add(filteredText);
+
+                }
             }
-
-            // Next we can obtain the tags (all have class 'app_tag')
-            Output.LogProgress("Obtaining tags");
-            IEnumerable<HtmlAgilityPack.HtmlNode> tagNodes = Fizzler.Systems.HtmlAgilityPack.HtmlNodeSelection.QuerySelectorAll(document.DocumentNode, "a.app_tag");
-
-            // Iterate through and add to the game's tags.
-            Output.LogProgress("Adding tags to list");
-            foreach (HtmlAgilityPack.HtmlNode node in tagNodes)
-            {
-                // Tags have awkward formatting like "\r\n\t\t\t\t\t\t\t\t\t\t\t\tFPS\t\t\t\t\t\t\t\t\t\t\t\t"
-                // This filter removes all the leading/trailing special characters.
-                string filteredText = node.InnerText.Substring(14, node.InnerText.Length - 26);
-                game.tags.Add(filteredText);
-
-            }
-
         }
 	}
 }

--- a/SteamAPI/SteamStorePage.cs
+++ b/SteamAPI/SteamStorePage.cs
@@ -20,20 +20,25 @@ namespace SteamAPI
             //
 
             // We know the appID already, and Steam makes it very convenient to find store pages based on this.
+            Output.LogProgress("Requesting store page");
             string StorePage = HTMLRequest.GetHTMLPage("https://store.steampowered.com/app/"+game.appid);
+            Output.LogProgress("Converting store page to document");
             HtmlAgilityPack.HtmlDocument document = new HtmlAgilityPack.HtmlDocument();
             document.LoadHtml(StorePage);
 
             // Next we can obtain the tags (all have class 'app_tag')
+            Output.LogProgress("Obtaining tags");
             IEnumerable<HtmlAgilityPack.HtmlNode> tagNodes = Fizzler.Systems.HtmlAgilityPack.HtmlNodeSelection.QuerySelectorAll(document.DocumentNode, "a.app_tag");
 
             // Iterate through and add to the game's tags.
+            Output.LogProgress("Adding tags to list");
             foreach (HtmlAgilityPack.HtmlNode node in tagNodes)
             {
                 // Tags have awkward formatting like "\r\n\t\t\t\t\t\t\t\t\t\t\t\tFPS\t\t\t\t\t\t\t\t\t\t\t\t"
                 // This filter removes all the leading/trailing special characters.
                 string filteredText = node.InnerText.Substring(14, node.InnerText.Length - 26);
                 game.tags.Add(filteredText);
+
             }
 
         }

--- a/SteamAPI/SteamUserPage.cs
+++ b/SteamAPI/SteamUserPage.cs
@@ -1,0 +1,30 @@
+﻿/*
+ *      -- SteamUserPage.cs --
+ *      By: Ash Duck
+ *      Date: 05/02/2024
+ *      Description: This file retrieves data from Steam User Pages (in HTML) and parses relevant information.
+ */
+
+namespace SteamAPI
+{
+	public class SteamUserPage
+	{
+		public static void GetUserLevel(User user, string url)
+		{
+            //
+            // This method gets the user level from a given URL and populates a user object with the data.
+            // Requires: user != null, Steam Community URL
+            //
+
+            string UserPage = HTMLRequest.GetHTMLPage(url);
+			HtmlAgilityPack.HtmlDocument document = new HtmlAgilityPack.HtmlDocument();
+			document.LoadHtml(UserPage);
+
+			// There is only a single node with this class, and inside is the user level.
+			HtmlAgilityPack.HtmlNode levelNode = Fizzler.Systems.HtmlAgilityPack.HtmlNodeSelection.QuerySelectorAll(document.DocumentNode, "span.friendPlayerLevelNum").First();
+
+			user.userLevel = int.Parse(levelNode.InnerText);
+		}
+	}
+}
+

--- a/SteamAPI/SteamUserPage.cs
+++ b/SteamAPI/SteamUserPage.cs
@@ -17,10 +17,10 @@ namespace SteamAPI
 			//
 
 			Output.LogProgress("Requesting user page (HTML)");
-            string UserPage = HTMLRequest.GetHTMLPage(url);
+            string userPage = HTMLRequest.GetHTMLPage(url);
 			Output.LogProgress("Converting user page to document");
 			HtmlAgilityPack.HtmlDocument document = new HtmlAgilityPack.HtmlDocument();
-			document.LoadHtml(UserPage);
+			document.LoadHtml(userPage);
 
 			// There is only a single node with this class, and inside is the user level.
 			Output.LogProgress("Obtaining the user's level");

--- a/SteamAPI/SteamUserPage.cs
+++ b/SteamAPI/SteamUserPage.cs
@@ -11,16 +11,19 @@ namespace SteamAPI
 	{
 		public static void GetUserLevel(User user, string url)
 		{
-            //
-            // This method gets the user level from a given URL and populates a user object with the data.
-            // Requires: user != null, Steam Community URL
-            //
+			//
+			// This method gets the user level from a given URL and populates a user object with the data.
+			// Requires: user != null, Steam Community URL
+			//
 
+			Output.LogProgress("Requesting user page (HTML)");
             string UserPage = HTMLRequest.GetHTMLPage(url);
+			Output.LogProgress("Converting user page to document");
 			HtmlAgilityPack.HtmlDocument document = new HtmlAgilityPack.HtmlDocument();
 			document.LoadHtml(UserPage);
 
 			// There is only a single node with this class, and inside is the user level.
+			Output.LogProgress("Obtaining the user's level");
 			HtmlAgilityPack.HtmlNode levelNode = Fizzler.Systems.HtmlAgilityPack.HtmlNodeSelection.QuerySelectorAll(document.DocumentNode, "span.friendPlayerLevelNum").First();
 
 			user.userLevel = int.Parse(levelNode.InnerText);

--- a/SteamAPI/SteamWeb.cs
+++ b/SteamAPI/SteamWeb.cs
@@ -35,7 +35,9 @@ namespace SteamAPI
 
             const string reqPath = "IPlayerService/GetOwnedGames/v0001/?steamid";
 
+            Output.LogProgress("Requesting user summary from Web API");
             JsonElement response = MakeWebAPIRequest(reqPath, user.steamID64, "&include_appinfo=true");         // This is the bit we care about
+            Output.LogProgress("Adding games to gamesList");
             foreach (var game in response.GetProperty("games").EnumerateArray())                                // Games are (understandably) stored in an array as JSON objects
             {
                 JsonElement gameInfo = JsonSerializer.Deserialize<JsonElement>(game);                           // To work with them, we have to deserialize them

--- a/SteamAPI/SteamXML.cs
+++ b/SteamAPI/SteamXML.cs
@@ -21,18 +21,22 @@ namespace SteamAPI
             // This could become a bool in future to signify Public/Private acc (true/false) to halt other areas of the code executing.
 
             // XML parsing is slow, I don't really want to do it multiple times.
+            Output.LogProgress("Requesting Community XML");
             string XMLPage = HTMLRequest.GetHTMLPage(url + "?xml=1");
+            Output.LogProgress("Converting response to document");
             XmlDocument document = new XmlDocument();
             document.LoadXml(XMLPage);
 
             // These paths are always the same (unless Valve updates the format, which would not be great.)
             // Even though VS complains they *may* be null, it can be assumed they won't be.
+            Output.LogProgress("Finding id64, id, vac & member");
             string id64 = document.SelectSingleNode("/profile/steamID64").InnerText;
             string id = document.SelectSingleNode("/profile/steamID").InnerText;
             string vac = document.SelectSingleNode("/profile/vacBanned").InnerText;
             string member = document.SelectSingleNode("/profile/memberSince").InnerText;
 
             // They all come back as strings, so I do all the conversions here.
+            Output.LogProgress("Converting all to correct types");
             user.steamID64 = ulong.Parse(id64);
             user.steamID = id;
             user.vacBanned = Convert.ToBoolean(int.Parse(vac));

--- a/SteamAPI/User.cs
+++ b/SteamAPI/User.cs
@@ -15,7 +15,7 @@ namespace SteamAPI
         public bool vacBanned;
         public string memberSince;      // At the minute this is a string -- this is probably better as a datetime and then we can do calculations with it?
         public int userLevel;
-
+        
         // Obtainable via Web API
         public List<Game> gamesList;
 

--- a/SteamAPI/User.cs
+++ b/SteamAPI/User.cs
@@ -14,6 +14,7 @@ namespace SteamAPI
         public string steamID;
         public bool vacBanned;
         public string memberSince;      // At the minute this is a string -- this is probably better as a datetime and then we can do calculations with it?
+        public int userLevel;
 
         // Obtainable via Web API
         public List<Game> gamesList;
@@ -25,6 +26,7 @@ namespace SteamAPI
             steamID = "";
             vacBanned = false;
             memberSince = "";
+            userLevel = -1;
 
             gamesList = new List<Game>();
         }
@@ -40,6 +42,7 @@ namespace SteamAPI
 
             for (int i = 0; i < 5; i++)
             {
+                SteamStorePage.GetCommunityTags(sortedPlaytime[i]);
                 playtimeString += sortedPlaytime[i].ToString();
             }
 
@@ -59,7 +62,7 @@ namespace SteamAPI
                 }
             }
 
-            return $"Steam ID64: {steamID64}\n\tSteam ID: {steamID}\n\tVAC Banned: {vacBanned}\n\tMember Since: {memberSince}\n\nTop 5 Most Played Games:\n{playtimeString}\nTop 5 Recently Played Games:\n{recentPlaytime}\n";
+            return $"Steam ID64: {steamID64}\n\tSteam ID: {steamID}\n\tUser Level: {userLevel}\n\tVAC Banned: {vacBanned}\n\tMember Since: {memberSince}\n\nTop 5 Most Played Games:\n{playtimeString}\nTop 5 Recently Played Games:\n{recentPlaytime}\n";
         }
     }
 }

--- a/SteamAPI/User.cs
+++ b/SteamAPI/User.cs
@@ -58,6 +58,7 @@ namespace SteamAPI
             {
                 if (sortedPlaytime[i].playtime_2weeks != 0)
                 {
+                    SteamStorePage.GetCommunityTags(sortedPlaytime[i]);
                     recentPlaytime += sortedPlaytime[i].ToString();
                 }
             }


### PR DESCRIPTION
Adds extra information that the API can obtain. This includes:
- User Level
- Game tags (genres)

This is done via obtaining full webpages. As a result, this should be used sparingly as it is much slower than making XML or Web API calls, though some information (such as the ones obtained here) can only be obtained by using full webpages.